### PR TITLE
Add host ip to forwarded port

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "ubuntu/trusty64"
 
-  config.vm.network :forwarded_port, guest: 8080, host: 8181 # Tomcat
+  config.vm.network :forwarded_port, guest: 8080, host: 8181, host_ip: "127.0.0.1" # Tomcat
 
   config.vm.provider "virtualbox" do |v|
     v.memory = 2048


### PR DESCRIPTION
I needed to manually add a host ip in virtual box to get GeoServer to show in my browser.
